### PR TITLE
Inline validation test values

### DIFF
--- a/jsonschema/validate.go
+++ b/jsonschema/validate.go
@@ -36,6 +36,10 @@ func Validate(schema Definition, data any) bool {
 		_, ok := data.(bool)
 		return ok
 	case Integer:
+		// Golang unmarshals all numbers as float64, so we need to check if the float64 is an integer
+		if num, ok := data.(float64); ok {
+			return num == float64(int64(num))
+		}
 		_, ok := data.(int)
 		return ok
 	case Null:

--- a/jsonschema/validate_test.go
+++ b/jsonschema/validate_test.go
@@ -86,17 +86,9 @@ func TestUnmarshal(t *testing.T) {
 		content []byte
 		v       any
 	}
-	var result1 struct {
+	type numberResult struct {
 		String string  `json:"string"`
 		Number float64 `json:"number"`
-	}
-	var result2 struct {
-		String string  `json:"string"`
-		Number float64 `json:"number"`
-	}
-	var result3 struct {
-		String  string `json:"string"`
-		Integer int    `json:"integer"`
 	}
 	tests := []struct {
 		name    string
@@ -112,7 +104,7 @@ func TestUnmarshal(t *testing.T) {
 				},
 			},
 			content: []byte(`{"string":"abc","number":123.4}`),
-			v:       &result1,
+			v:       &(numberResult{}),
 		}, false},
 		{"", args{
 			schema: jsonschema.Definition{
@@ -124,31 +116,29 @@ func TestUnmarshal(t *testing.T) {
 				Required: []string{"string", "number"},
 			},
 			content: []byte(`{"string":"abc"}`),
-			v:       result2,
+			v:       numberResult{},
 		}, true},
 		{"validate integer", args{
 			schema: jsonschema.Definition{
 				Type: jsonschema.Object,
 				Properties: map[string]jsonschema.Definition{
-					"string":  {Type: jsonschema.String},
 					"integer": {Type: jsonschema.Integer},
 				},
-				Required: []string{"string", "integer"},
+				Required: []string{"integer"},
 			},
-			content: []byte(`{"string":"abc","integer":123}`),
-			v:       &result3,
+			content: []byte(`{"integer":123}`),
+			v:       &(struct{ integer int }{}),
 		}, false},
 		{"validate integer failed", args{
 			schema: jsonschema.Definition{
 				Type: jsonschema.Object,
 				Properties: map[string]jsonschema.Definition{
-					"string":  {Type: jsonschema.String},
 					"integer": {Type: jsonschema.Integer},
 				},
-				Required: []string{"string", "integer"},
+				Required: []string{"integer"},
 			},
-			content: []byte(`{"string":"abc","integer":123.4}`),
-			v:       &result3,
+			content: []byte(`{"integer":123.4}`),
+			v:       &(struct{ integer int }{}),
 		}, true},
 	}
 	for _, tt := range tests {

--- a/jsonschema/validate_test.go
+++ b/jsonschema/validate_test.go
@@ -94,6 +94,10 @@ func TestUnmarshal(t *testing.T) {
 		String string  `json:"string"`
 		Number float64 `json:"number"`
 	}
+	var result3 struct {
+		String  string `json:"string"`
+		Integer int    `json:"integer"`
+	}
 	tests := []struct {
 		name    string
 		args    args
@@ -121,6 +125,30 @@ func TestUnmarshal(t *testing.T) {
 			},
 			content: []byte(`{"string":"abc"}`),
 			v:       result2,
+		}, true},
+		{"validate integer", args{
+			schema: jsonschema.Definition{
+				Type: jsonschema.Object,
+				Properties: map[string]jsonschema.Definition{
+					"string":  {Type: jsonschema.String},
+					"integer": {Type: jsonschema.Integer},
+				},
+				Required: []string{"string", "integer"},
+			},
+			content: []byte(`{"string":"abc","integer":123}`),
+			v:       &result3,
+		}, false},
+		{"validate integer failed", args{
+			schema: jsonschema.Definition{
+				Type: jsonschema.Object,
+				Properties: map[string]jsonschema.Definition{
+					"string":  {Type: jsonschema.String},
+					"integer": {Type: jsonschema.Integer},
+				},
+				Required: []string{"string", "integer"},
+			},
+			content: []byte(`{"string":"abc","integer":123.4}`),
+			v:       &result3,
 		}, true},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
I noticed that sashabaranov requested changes in your PR.  I think this is approximately what was being requested in the PR comments, regarding inlining the "result1,2,3" values.

There are some broken tests elsewhere in `json_test.go` but all the `validation_test` tests work the same under this change.